### PR TITLE
Fix invalid directives (Fixes #15)

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,13 +1,20 @@
 {
-    "name": "ExportPDF",
-    "version": "0.2",
-    "title": "PDF Export",
-    "description": "Export a file or a selection to PDf.",
-    "homepage": "https://github.com/Liongold/brackets-pdfexport",
-    "author": "Jean Spiteri <beimaginativeegroup@gmail.com>, Steffen Bruchmann <hi@sbruchmann.me>",
-    "license": "MIT",
-    "keywords": [
-        "export",
-        "pdf"
-    ]
+  "name": "ExportPDF",
+  "version": "1.0.0",
+  "title": "PDF Export",
+  "description": "Export a file or a selection to PDf.",
+  "homepage": "https://github.com/Liongold/brackets-pdfexport",
+  "author": "Jean Spiteri <beimaginativeegroup@gmail.com>",
+  "contributors": [
+      {
+          "email": "hi@sbruchmann.me",
+          "name": "Steffen Bruchmann",
+          "url": "http://sbruchmann.me"
+      }
+  ],
+  "license": "MIT",
+  "keywords": [
+      "export",
+      "pdf"
+  ]
 }


### PR DESCRIPTION
This commit is fixing invalid directives
and reverting some changes that were
introduced in fb5afeb.

Rebased commits:
- Reset version number to 1.0.0
- Split authors into auto and contributors
- Set indentation to two spaces
