### PR TITLE
Implement opening of exported PDF with default app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+node_modules/
 .brackets.json
 .todo

--- a/src/Dialogs.js
+++ b/src/Dialogs.js
@@ -21,7 +21,8 @@ define(function (require, exports) {
      * @type {object.<string, string>}
      */
     var _selectors = {
-        fontSize: "#pdfexport-fontsize"
+        fontSize: "#pdfexport-fontsize",
+        openPdf: "#pdfexport-openpdf"
     };
 
     /**
@@ -77,7 +78,8 @@ define(function (require, exports) {
 
             if (action === _ACTION_SAVEAS) {
                 response = {
-                    fontSize: parseInt($element.find(_selectors.fontSize).val(), 10)
+                    fontSize: parseInt($element.find(_selectors.fontSize).val(), 10),
+                    openPdf: $element.find(_selectors.openPdf).prop("checked")
                 };
             }
 

--- a/src/FileSystemDomain.js
+++ b/src/FileSystemDomain.js
@@ -2,6 +2,7 @@
 
 // Dependencies
 var fs = require("fs");
+var opn = require("opn");
 
 /**
  * @const
@@ -22,6 +23,7 @@ function init(manager) {
         });
     }
     manager.registerCommand(_DOMAIN_ID, "write", write, true);
+    manager.registerCommand(_DOMAIN_ID, "open", opn);
 }
 
 /**

--- a/src/PDFDocument.js
+++ b/src/PDFDocument.js
@@ -44,7 +44,9 @@ define(function (require, exports, module) {
             /**
              * @TODO Implement error dialog for write errors
              */
-            _fs.exec("write", pathname, reader.result);
+            _fs.exec("write", pathname, reader.result)
+                .fail(deferred.reject.bind(deferred))
+                .then(deferred.resolve.bind(deferred));
         };
 
         return deferred.promise();
@@ -83,6 +85,11 @@ define(function (require, exports, module) {
         return deferred.promise();
     }
 
+    function open(pathname) {
+        _fs.exec("open", pathname);
+    }
+
     // Define public API
     exports.create = create;
+    exports.open = open;
 });

--- a/src/htmlContent/export-dialog.html
+++ b/src/htmlContent/export-dialog.html
@@ -9,6 +9,14 @@
                     <input min="1" id="pdfexport-fontsize" step="1" type="number" value="10" />
                 </div>
             </div>
+            <div class="control-group">
+                <label class="control-label" for="pdfexport-openpdf">
+                    <%= Nls.LABEL_OPENPDF %>
+                </label>
+                <div class="controls">
+                    <input checked id="pdfexport-openpdf" type="checkbox" />
+                </div>
+            </div>
         </form>
     </div>
 </div>

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ define(function (require) {
     }
 
     /**
-     * @param {{fontSize: number, pathname: string, text: string}} options
+     * @param {{fontSize: number, openPdf: boolean, pathname: string, text: string}} options
      */
     function _savePDFFile(options) {
         PDFDocument.create(options)
@@ -37,6 +37,11 @@ define(function (require) {
                 /**
                  * @TODO Use error codes in order to simplify displaying of error dialogs
                  */
+            })
+            .then(function() {
+                if (options.openPdf) {
+                    PDFDocument.open(options.pathname);
+                }
             });
     }
 
@@ -74,6 +79,7 @@ define(function (require) {
                 function _saveDialogCallback(err, pathname) {
                     _savePDFFile({
                         fontSize: options.fontSize,
+                        openPdf: options.openPdf,
                         srcFile: srcFile,
                         pathname: pathname,
                         text: doc.getText()

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -5,5 +5,6 @@ define({
     "ERROR_PDFKIT_TITLE":           "Unexpected Error",
     "ERROR_UNSUPPORTED_FILE_MSG":   "The following file is not supported and can not be exported as a PDF document: {0}",
     "ERROR_UNSUPPORTED_FILE_TITLE": "Unsupported File",
-    "LABEL_FONTSIZE":               "Font Size"
+    "LABEL_FONTSIZE":               "Font Size",
+    "LABEL_OPENPDF":                "Open PDF After Export"
 });

--- a/src/package.json
+++ b/src/package.json
@@ -6,15 +6,18 @@
   "homepage": "https://github.com/Liongold/brackets-pdfexport",
   "author": "Jean Spiteri <beimaginativeegroup@gmail.com>",
   "contributors": [
-      {
-          "email": "hi@sbruchmann.me",
-          "name": "Steffen Bruchmann",
-          "url": "http://sbruchmann.me"
-      }
+    {
+      "email": "hi@sbruchmann.me",
+      "name": "Steffen Bruchmann",
+      "url": "http://sbruchmann.me"
+    }
   ],
   "license": "MIT",
   "keywords": [
-      "export",
-      "pdf"
-  ]
+    "export",
+    "pdf"
+  ],
+  "dependencies": {
+    "opn": "^1.0.0"
+  }
 }


### PR DESCRIPTION
---

This is a rebased version of #17. It’s ready to merge, if there’s nothing more to change at this point in time.

---

This commit implements the automatic opening of exported
PDF documents with the system default app. It can be
toggled via a checkbox in the export dialog.

NOTE: This is temporary code, since I am not too happy
with the `PDFDocument.open` method. I'll have to think
about that for a while first.

Squashed commits:
- Ignore node_modules/
- Open PDF document after export
- Implement UI for toggling opening of PDF documents