### PR TITLE
 Implement opening of exported PDF with default app 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+node_modules/
 .brackets.json
 .todo

--- a/src/Dialogs.js
+++ b/src/Dialogs.js
@@ -33,7 +33,6 @@ define(function (require, exports) {
      * @private
      * @type {object.<string, string>}
      */
-<<<<<<< HEAD
     var _selectors = { 
         bottomMargin: "#docBottomMargin",
         content: "input[name='pdfexport-content']:checked",
@@ -41,12 +40,8 @@ define(function (require, exports) {
         includepagenumbers: "#pdfexport-includepages", 
         leftMargin: "#docLeftMargin",
         rightMargin: "#docRightMargin",
-        topMargin: "#docTopMargin"
-=======
-    var _selectors = {
-        fontSize: "#pdfexport-fontsize",
+        topMargin: "#docTopMargin",
         openPdf: "#pdfexport-openpdf"
->>>>>>> feature/implement-issue-10
     };
 
     /**
@@ -120,7 +115,7 @@ define(function (require, exports) {
                         left: parseInt($element.find(_selectors.leftMargin).val(), 10),
                         right: parseInt($element.find(_selectors.rightMargin).val(), 10),
                         top: parseInt($element.find(_selectors.topMargin).val(), 10),
-                    }
+                    },
                     includepagenumbers: $element.find(_selectors.includepagenumbers).is(':checked'),
                     openPdf: $element.find(_selectors.openPdf).prop("checked")
                 };

--- a/src/Dialogs.js
+++ b/src/Dialogs.js
@@ -33,6 +33,7 @@ define(function (require, exports) {
      * @private
      * @type {object.<string, string>}
      */
+<<<<<<< HEAD
     var _selectors = { 
         bottomMargin: "#docBottomMargin",
         content: "input[name='pdfexport-content']:checked",
@@ -41,6 +42,11 @@ define(function (require, exports) {
         leftMargin: "#docLeftMargin",
         rightMargin: "#docRightMargin",
         topMargin: "#docTopMargin"
+=======
+    var _selectors = {
+        fontSize: "#pdfexport-fontsize",
+        openPdf: "#pdfexport-openpdf"
+>>>>>>> feature/implement-issue-10
     };
 
     /**
@@ -115,7 +121,8 @@ define(function (require, exports) {
                         right: parseInt($element.find(_selectors.rightMargin).val(), 10),
                         top: parseInt($element.find(_selectors.topMargin).val(), 10),
                     }
-                    includepagenumbers: $element.find(_selectors.includepagenumbers).is(':checked')
+                    includepagenumbers: $element.find(_selectors.includepagenumbers).is(':checked'),
+                    openPdf: $element.find(_selectors.openPdf).prop("checked")
                 };
             } else if (action === _ACTION_OPEN_PREFERENCES) { 
                 dialog.close();

--- a/src/FileSystemDomain.js
+++ b/src/FileSystemDomain.js
@@ -23,7 +23,7 @@ function init(manager) {
         });
     }
     manager.registerCommand(_DOMAIN_ID, "write", write, true);
-    manager.registerCommand(_DOMAIN_ID, "open", opn);
+    manager.registerCommand(_DOMAIN_ID, "open", open);
 }
 
 /**
@@ -36,6 +36,14 @@ function write(pathname, data, done) {
     // Omit file header from input data
     data = data.split(",")[1];
     fs.writeFile(pathname, data, "base64", done);
+}
+
+/**
+ * @public
+ * @param {!string} pathname
+ */
+function open(pathname) {
+    opn(pathname, {});
 }
 
 // Define public API

--- a/src/FileSystemDomain.js
+++ b/src/FileSystemDomain.js
@@ -2,6 +2,7 @@
 
 // Dependencies
 var fs = require("fs");
+var opn = require("opn");
 
 /**
  * @const
@@ -22,6 +23,7 @@ function init(manager) {
         });
     }
     manager.registerCommand(_DOMAIN_ID, "write", write, true);
+    manager.registerCommand(_DOMAIN_ID, "open", opn);
 }
 
 /**

--- a/src/PDFDocument.js
+++ b/src/PDFDocument.js
@@ -51,7 +51,9 @@ define(function (require, exports, module) {
                         Nls.ERROR_WRITE_MSG,
                         err.errno
                     );
-            });
+                    deferred.reject.bind(deferred);
+                })
+                .then(deferred.resolve.bind(deferred));
         };
 
         return deferred.promise();
@@ -132,6 +134,11 @@ define(function (require, exports, module) {
         return deferred.promise();
     }
 
+    function open(pathname) {
+        _fs.exec("open", pathname);
+    }
+
     // Define public API
     exports.create = create;
+    exports.open = open;
 });

--- a/src/htmlContent/export-dialog.html
+++ b/src/htmlContent/export-dialog.html
@@ -34,6 +34,7 @@
                     </div>
                 </div>
             </div>
+<<<<<<< HEAD
         </div>
         <div class="span3">
             <form class="form-horizontal">
@@ -54,8 +55,8 @@
                     </div>
                 </div>
                 <div class="control-group">
-                    <label class="checkbox" for="pdfexport-openfile">
-                        <input type="checkbox" <% if(Preferences.getPreference('openAfterExport')) { %>checked<% } %> id="pdfexport-openfile"><%= Nls.LABEL_OPENPDF %>
+                    <label class="checkbox" for="pdfexport-openpdf">
+                        <input type="checkbox" <% if(Preferences.getPreference('openAfterExport')) { %>checked<% } %> id="pdfexport-openpdf"><%= Nls.LABEL_OPENPDF %>
                     </label>
                 </div>
                 <div class="control-group"> 

--- a/src/htmlContent/export-dialog.html
+++ b/src/htmlContent/export-dialog.html
@@ -34,7 +34,6 @@
                     </div>
                 </div>
             </div>
-<<<<<<< HEAD
         </div>
         <div class="span3">
             <form class="form-horizontal">

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ define(function (require) {
     }
 
     /**
-     * @param {{fontSize: number, pathname: string, text: string, margins: object,includePageNumbers: boolean, syntaxHighlight: boolean}} options
+     * @param {{fontSize: number, openPdf: boolean, pathname: string, text: string, margins: object,includePageNumbers: boolean, syntaxHighlight: boolean}} options
      */
     function _savePDFFile(options) { 
         $("body").append("<div class='modal-wrapper'><div class='modal-inner-wrapper'><div class='modal-backdrop in' style='z-index:1052;'></div></div></div>");
@@ -41,6 +41,11 @@ define(function (require) {
             })
             .always(function () {
                 $(".modal-wrapper").remove();
+            })
+            .then(function() {
+                if (options.openPdf) {
+                    PDFDocument.open(options.pathname);
+                }
             });
     }
 
@@ -168,6 +173,7 @@ define(function (require) {
                 function _saveDialogCallback(err, pathname) {
                     _savePDFFile({ 
                         fontSize: options.fontSize,
+                        openPdf: options.openPdf,
                         srcFile: srcFile,
                         pathname: pathname,
                         text: text,

--- a/src/package.json
+++ b/src/package.json
@@ -13,7 +13,10 @@
     }
   ],
   "license": "MIT",
-  "i18n": ["en", "it" ],
+  "i18n": [
+    "en",
+    "it"
+  ],
   "keywords": [
     "export",
     "pdf"

--- a/src/package.json
+++ b/src/package.json
@@ -29,5 +29,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/Liongold/brackets-pdfexport"
+  },
+  "dependencies": {
+    "opn": "^1.0.0"
   }
 }


### PR DESCRIPTION
---

This feature is the result of work by @sbruchmann. The only thing I have done is to fix a bug in the open function which did not allow the open mechanism to work as it should. I have also fixed conflicts which can arise during merging. The original pull request was #19 and the original description has been copied here for reference. 

---

This is a rebased version of #17. It’s ready to merge, if there’s nothing more to change at this point in time.

---
This commit implements the automatic opening of exported
PDF documents with the system default app. It can be
toggled via a checkbox in the export dialog.

NOTE: This is temporary code, since I am not too happy
with the `PDFDocument.open` method. I'll have to think
about that for a while first.

Squashed commits:
- Ignore node_modules/
- Open PDF document after export
- Implement UI for toggling opening of PDF documents